### PR TITLE
chore: sync p2p workflow inputs

### DIFF
--- a/.github/workflows/extended-test.yaml
+++ b/.github/workflows/extended-test.yaml
@@ -38,11 +38,14 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
     with:
       image-name: ${{ needs.get-image-name.outputs.image-name }}
+      tenant-name: ${{ inputs.lifecycle }}
 
   extended-tests:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     with:
+      app-name: ${{ inputs.lifecycle }}
+      tenant-name: ${{ inputs.lifecycle }}
       working-directory: './${{ inputs.lifecycle }}'
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: '${{ inputs.lifecycle }}/v'

--- a/.github/workflows/fast-feedback.yaml
+++ b/.github/workflows/fast-feedback.yaml
@@ -31,5 +31,7 @@ jobs:
     needs: [version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     with:
+      app-name: ${{ inputs.lifecycle }}
+      tenant-name: ${{ inputs.lifecycle }}
       working-directory: './${{ inputs.lifecycle }}'
       version: ${{ needs.version.outputs.version }}

--- a/.github/workflows/p2p.yaml
+++ b/.github/workflows/p2p.yaml
@@ -38,6 +38,7 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
+      tenant-name: ${{ inputs.lifecycle }}
       version: ${{ needs.version.outputs.version }}
       working-directory: './${{ inputs.lifecycle }}'
       checkout-version: ${{ inputs.ref }}
@@ -46,6 +47,7 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
+      tenant-name: ${{ inputs.lifecycle }}
       version: ${{ needs.version.outputs.version }}
       version-prefix: '${{ inputs.lifecycle }}/v'
       working-directory: './${{ inputs.lifecycle }}'
@@ -54,6 +56,7 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
+      tenant-name: ${{ inputs.lifecycle }}
       version: ${{ needs.version.outputs.version }}
       version-prefix: '${{ inputs.lifecycle }}/v'
       working-directory: './${{ inputs.lifecycle }}'

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -37,11 +37,14 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
     with:
       image-name: ${{ needs.get-image-name.outputs.image-name }}
+      tenant-name: ${{ inputs.lifecycle }}
 
   prod:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     with:
+      app-name: ${{ inputs.lifecycle }}
+      tenant-name: ${{ inputs.lifecycle }}
       working-directory: './${{ inputs.lifecycle }}'
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: '${{ inputs.lifecycle }}/v'


### PR DESCRIPTION
## Summary
- add the missing `tenant-name` inputs to the custom P2P wrapper workflows
- use the shared `reference-applications` tenant across all wrapper workflow invocations while preserving per-lifecycle `app-name` values
- align the reference application workflows with the current reusable P2P workflow contract