### PR TITLE
chore: use shared reference applications tenant

### DIFF
--- a/.github/workflows/extended-test.yaml
+++ b/.github/workflows/extended-test.yaml
@@ -38,14 +38,14 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
     with:
       image-name: ${{ needs.get-image-name.outputs.image-name }}
-      tenant-name: ${{ inputs.lifecycle }}
+      tenant-name: reference-applications
 
   extended-tests:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
-      tenant-name: ${{ inputs.lifecycle }}
+      tenant-name: reference-applications
       working-directory: './${{ inputs.lifecycle }}'
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: '${{ inputs.lifecycle }}/v'

--- a/.github/workflows/fast-feedback.yaml
+++ b/.github/workflows/fast-feedback.yaml
@@ -32,6 +32,6 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
-      tenant-name: ${{ inputs.lifecycle }}
+      tenant-name: reference-applications
       working-directory: './${{ inputs.lifecycle }}'
       version: ${{ needs.version.outputs.version }}

--- a/.github/workflows/p2p.yaml
+++ b/.github/workflows/p2p.yaml
@@ -38,7 +38,7 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
-      tenant-name: ${{ inputs.lifecycle }}
+      tenant-name: reference-applications
       version: ${{ needs.version.outputs.version }}
       working-directory: './${{ inputs.lifecycle }}'
       checkout-version: ${{ inputs.ref }}
@@ -47,7 +47,7 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
-      tenant-name: ${{ inputs.lifecycle }}
+      tenant-name: reference-applications
       version: ${{ needs.version.outputs.version }}
       version-prefix: '${{ inputs.lifecycle }}/v'
       working-directory: './${{ inputs.lifecycle }}'
@@ -56,7 +56,7 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
-      tenant-name: ${{ inputs.lifecycle }}
+      tenant-name: reference-applications
       version: ${{ needs.version.outputs.version }}
       version-prefix: '${{ inputs.lifecycle }}/v'
       working-directory: './${{ inputs.lifecycle }}'

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -37,14 +37,14 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
     with:
       image-name: ${{ needs.get-image-name.outputs.image-name }}
-      tenant-name: ${{ inputs.lifecycle }}
+      tenant-name: reference-applications
 
   prod:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
-      tenant-name: ${{ inputs.lifecycle }}
+      tenant-name: reference-applications
       working-directory: './${{ inputs.lifecycle }}'
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: '${{ inputs.lifecycle }}/v'


### PR DESCRIPTION
## Summary
- update the custom P2P wrapper workflows to use the shared `reference-applications` tenant
- preserve per-lifecycle `app-name` values while keeping tenant configuration consistent across fast-feedback, extended-test, prod, and full P2P workflows
- align the reference application workflows with the current reusable P2P workflow contract