### PR TITLE
Use per-app tenants for reference applications

### DIFF
--- a/.github/data/args.yaml
+++ b/.github/data/args.yaml
@@ -1,3 +1,2 @@
-tenant: $(TENANT_NAME)
 working_directory: ./
 version_prefix: v

--- a/.github/scripts/collect_changed_templates.sh
+++ b/.github/scripts/collect_changed_templates.sh
@@ -46,7 +46,7 @@ for t in "${all_templates[@]}"; do
   echo "Rendering template '$t'"
   rm -rf "./$reference_apps_dir/$t"
   mkdir -p "./$reference_apps_dir/$t"
-  corectl template render "$t" "./$reference_apps_dir/$t" --templates "$templates_dir" --args-file "$args_file" -a "name=$t"
+  corectl template render "$t" "./$reference_apps_dir/$t" --templates "$templates_dir" --args-file "$args_file" -a "name=$t" -a "tenant=$t"
   git -C "./$reference_apps_dir" add "./$t"
   if [[ "$(git -C "$reference_apps_dir" status "./$t" --untracked-files=no --porcelain)" ]]; then
     echo "Template '$t' has changed!"

--- a/.github/workflows/extended-test.yaml
+++ b/.github/workflows/extended-test.yaml
@@ -38,14 +38,14 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
     with:
       image-name: ${{ needs.get-image-name.outputs.image-name }}
-      tenant-name: reference-applications
+      tenant-name: ${{ inputs.lifecycle }}
 
   extended-tests:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
-      tenant-name: reference-applications
+      tenant-name: ${{ inputs.lifecycle }}
       working-directory: './${{ inputs.lifecycle }}'
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: '${{ inputs.lifecycle }}/v'

--- a/.github/workflows/fast-feedback.yaml
+++ b/.github/workflows/fast-feedback.yaml
@@ -32,6 +32,6 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
-      tenant-name: reference-applications
+      tenant-name: ${{ inputs.lifecycle }}
       working-directory: './${{ inputs.lifecycle }}'
       version: ${{ needs.version.outputs.version }}

--- a/.github/workflows/p2p.yaml
+++ b/.github/workflows/p2p.yaml
@@ -38,7 +38,7 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
-      tenant-name: reference-applications
+      tenant-name: ${{ inputs.lifecycle }}
       version: ${{ needs.version.outputs.version }}
       working-directory: './${{ inputs.lifecycle }}'
       checkout-version: ${{ inputs.ref }}
@@ -47,7 +47,7 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
-      tenant-name: reference-applications
+      tenant-name: ${{ inputs.lifecycle }}
       version: ${{ needs.version.outputs.version }}
       version-prefix: '${{ inputs.lifecycle }}/v'
       working-directory: './${{ inputs.lifecycle }}'
@@ -56,7 +56,7 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
-      tenant-name: reference-applications
+      tenant-name: ${{ inputs.lifecycle }}
       version: ${{ needs.version.outputs.version }}
       version-prefix: '${{ inputs.lifecycle }}/v'
       working-directory: './${{ inputs.lifecycle }}'

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -37,14 +37,14 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
     with:
       image-name: ${{ needs.get-image-name.outputs.image-name }}
-      tenant-name: reference-applications
+      tenant-name: ${{ inputs.lifecycle }}
 
   prod:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     with:
       app-name: ${{ inputs.lifecycle }}
-      tenant-name: reference-applications
+      tenant-name: ${{ inputs.lifecycle }}
       working-directory: './${{ inputs.lifecycle }}'
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: '${{ inputs.lifecycle }}/v'

--- a/docker-web/.github/workflows/extended-test.yaml
+++ b/docker-web/.github/workflows/extended-test.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: docker-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: docker-web
 
   extendedtests:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: docker-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: docker-web
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/docker-web/.github/workflows/fast-feedback.yaml
+++ b/docker-web/.github/workflows/fast-feedback.yaml
@@ -34,6 +34,6 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: docker-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: docker-web
       version: ${{ needs.version.outputs.version }}
       working-directory: ./

--- a/docker-web/.github/workflows/prod.yaml
+++ b/docker-web/.github/workflows/prod.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: docker-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: docker-web
 
   prod:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: docker-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: docker-web
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/docker-web/Makefile
+++ b/docker-web/Makefile
@@ -1,5 +1,5 @@
 # Set tenant and app name
-P2P_TENANT_NAME ?= $(TENANT_NAME)
+P2P_TENANT_NAME ?= docker-web
 P2P_APP_NAME ?= docker-web
 
 # Download and include p2p makefile

--- a/go-web/.github/workflows/extended-test.yaml
+++ b/go-web/.github/workflows/extended-test.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: go-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: go-web
 
   extendedtests:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: go-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: go-web
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/go-web/.github/workflows/fast-feedback.yaml
+++ b/go-web/.github/workflows/fast-feedback.yaml
@@ -34,6 +34,6 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: go-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: go-web
       version: ${{ needs.version.outputs.version }}
       working-directory: ./

--- a/go-web/.github/workflows/prod.yaml
+++ b/go-web/.github/workflows/prod.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: go-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: go-web
 
   prod:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: go-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: go-web
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/go-web/Makefile
+++ b/go-web/Makefile
@@ -1,5 +1,5 @@
 # Set tenant and app name
-P2P_TENANT_NAME ?= $(TENANT_NAME)
+P2P_TENANT_NAME ?= go-web
 P2P_APP_NAME ?= go-web
 
 # Download and include p2p makefile

--- a/infra-cloudsql/.github/workflows/extended-test.yaml
+++ b/infra-cloudsql/.github/workflows/extended-test.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: infra-cloudsql
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-cloudsql
 
   extendedtests:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: infra-cloudsql
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-cloudsql
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/infra-cloudsql/.github/workflows/fast-feedback.yaml
+++ b/infra-cloudsql/.github/workflows/fast-feedback.yaml
@@ -34,6 +34,6 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: infra-cloudsql
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-cloudsql
       version: ${{ needs.version.outputs.version }}
       working-directory: ./

--- a/infra-cloudsql/.github/workflows/prod.yaml
+++ b/infra-cloudsql/.github/workflows/prod.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: infra-cloudsql
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-cloudsql
 
   prod:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: infra-cloudsql
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-cloudsql
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/infra-cloudsql/Makefile
+++ b/infra-cloudsql/Makefile
@@ -1,5 +1,5 @@
 # Set tenant and app name
-P2P_TENANT_NAME ?= $(TENANT_NAME)
+P2P_TENANT_NAME ?= infra-cloudsql
 P2P_APP_NAME ?= infra-cloudsql
 
 # Download and include p2p makefile

--- a/infra-tofu/.github/workflows/extended-test.yaml
+++ b/infra-tofu/.github/workflows/extended-test.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: infra-tofu
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-tofu
 
   extendedtests:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: infra-tofu
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-tofu
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/infra-tofu/.github/workflows/fast-feedback.yaml
+++ b/infra-tofu/.github/workflows/fast-feedback.yaml
@@ -34,6 +34,6 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: infra-tofu
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-tofu
       version: ${{ needs.version.outputs.version }}
       working-directory: ./

--- a/infra-tofu/.github/workflows/prod.yaml
+++ b/infra-tofu/.github/workflows/prod.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: infra-tofu
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-tofu
 
   prod:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: infra-tofu
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-tofu
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/infra-tofu/Makefile
+++ b/infra-tofu/Makefile
@@ -1,5 +1,5 @@
 # Set tenant and app name
-P2P_TENANT_NAME ?= $(TENANT_NAME)
+P2P_TENANT_NAME ?= infra-tofu
 P2P_APP_NAME ?= infra-tofu
 
 # Download and include p2p makefile

--- a/infra-urlrouter/.github/workflows/extended-test.yaml
+++ b/infra-urlrouter/.github/workflows/extended-test.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: infra-urlrouter
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-urlrouter
 
   extendedtests:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: infra-urlrouter
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-urlrouter
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/infra-urlrouter/.github/workflows/fast-feedback.yaml
+++ b/infra-urlrouter/.github/workflows/fast-feedback.yaml
@@ -34,6 +34,6 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: infra-urlrouter
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-urlrouter
       version: ${{ needs.version.outputs.version }}
       working-directory: ./

--- a/infra-urlrouter/.github/workflows/prod.yaml
+++ b/infra-urlrouter/.github/workflows/prod.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: infra-urlrouter
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-urlrouter
 
   prod:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: infra-urlrouter
-      tenant-name: $(TENANT_NAME)
+      tenant-name: infra-urlrouter
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/infra-urlrouter/Makefile
+++ b/infra-urlrouter/Makefile
@@ -1,5 +1,5 @@
 # Set tenant and app name
-P2P_TENANT_NAME ?= $(TENANT_NAME)
+P2P_TENANT_NAME ?= infra-urlrouter
 P2P_APP_NAME ?= infra-urlrouter
 
 # Download and include p2p makefile

--- a/java-web/.github/workflows/extended-test.yaml
+++ b/java-web/.github/workflows/extended-test.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: java-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: java-web
 
   extendedtests:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: java-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: java-web
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/java-web/.github/workflows/fast-feedback.yaml
+++ b/java-web/.github/workflows/fast-feedback.yaml
@@ -34,6 +34,6 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: java-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: java-web
       version: ${{ needs.version.outputs.version }}
       working-directory: ./

--- a/java-web/.github/workflows/prod.yaml
+++ b/java-web/.github/workflows/prod.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: java-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: java-web
 
   prod:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: java-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: java-web
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/java-web/Makefile
+++ b/java-web/Makefile
@@ -1,5 +1,5 @@
 # Set tenant and app name
-P2P_TENANT_NAME ?= $(TENANT_NAME)
+P2P_TENANT_NAME ?= java-web
 P2P_APP_NAME ?= java-web
 
 # Download and include p2p makefile

--- a/nextjs-web/.github/workflows/extended-test.yaml
+++ b/nextjs-web/.github/workflows/extended-test.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: nextjs-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: nextjs-web
 
   extendedtests:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: nextjs-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: nextjs-web
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/nextjs-web/.github/workflows/fast-feedback.yaml
+++ b/nextjs-web/.github/workflows/fast-feedback.yaml
@@ -34,6 +34,6 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: nextjs-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: nextjs-web
       version: ${{ needs.version.outputs.version }}
       working-directory: ./

--- a/nextjs-web/.github/workflows/prod.yaml
+++ b/nextjs-web/.github/workflows/prod.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: nextjs-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: nextjs-web
 
   prod:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: nextjs-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: nextjs-web
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/nextjs-web/Makefile
+++ b/nextjs-web/Makefile
@@ -1,5 +1,5 @@
 # Set tenant and app name
-P2P_TENANT_NAME ?= $(TENANT_NAME)
+P2P_TENANT_NAME ?= nextjs-web
 P2P_APP_NAME ?= nextjs-web
 
 # Download and include p2p makefile

--- a/python-web/.github/workflows/extended-test.yaml
+++ b/python-web/.github/workflows/extended-test.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: python-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: python-web
 
   extendedtests:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: python-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: python-web
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/python-web/.github/workflows/fast-feedback.yaml
+++ b/python-web/.github/workflows/fast-feedback.yaml
@@ -34,6 +34,6 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: python-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: python-web
       version: ${{ needs.version.outputs.version }}
       working-directory: ./

--- a/python-web/.github/workflows/prod.yaml
+++ b/python-web/.github/workflows/prod.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: python-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: python-web
 
   prod:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: python-web
-      tenant-name: $(TENANT_NAME)
+      tenant-name: python-web
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/python-web/Makefile
+++ b/python-web/Makefile
@@ -1,5 +1,5 @@
 # Set tenant and app name
-P2P_TENANT_NAME ?= $(TENANT_NAME)
+P2P_TENANT_NAME ?= python-web
 P2P_APP_NAME ?= python-web
 
 # Download and include p2p makefile

--- a/static-nextra/.github/workflows/extended-test.yaml
+++ b/static-nextra/.github/workflows/extended-test.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: static-nextra
-      tenant-name: $(TENANT_NAME)
+      tenant-name: static-nextra
 
   extendedtests:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: static-nextra
-      tenant-name: $(TENANT_NAME)
+      tenant-name: static-nextra
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/static-nextra/.github/workflows/fast-feedback.yaml
+++ b/static-nextra/.github/workflows/fast-feedback.yaml
@@ -34,6 +34,6 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: static-nextra
-      tenant-name: $(TENANT_NAME)
+      tenant-name: static-nextra
       version: ${{ needs.version.outputs.version }}
       working-directory: ./

--- a/static-nextra/.github/workflows/prod.yaml
+++ b/static-nextra/.github/workflows/prod.yaml
@@ -17,7 +17,7 @@ jobs:
       slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
     with:
       image-name: static-nextra
-      tenant-name: $(TENANT_NAME)
+      tenant-name: static-nextra
 
   prod:
     needs: [get-latest-version]
@@ -27,7 +27,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: static-nextra
-      tenant-name: $(TENANT_NAME)
+      tenant-name: static-nextra
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/static-nextra/Makefile
+++ b/static-nextra/Makefile
@@ -1,5 +1,5 @@
 # Set tenant and app name
-P2P_TENANT_NAME ?= $(TENANT_NAME)
+P2P_TENANT_NAME ?= static-nextra
 P2P_APP_NAME ?= static-nextra
 
 # Download and include p2p makefile


### PR DESCRIPTION
## Summary
- Deploy reusable lifecycle workflows to the tenant matching the lifecycle/application name.
- Replace generated per-app workflow tenant placeholders with explicit per-app tenant names.
- Pass `tenant=<app>` when rendering templates and align app Makefile tenant defaults.

## Validation
- Confirmed no YAML references remain to `reference-applications` or `tenant-name: $(TENANT_NAME)`.
- Parsed all repository workflow YAML files and `.github/data/args.yaml` with Ruby YAML.