### PR TITLE
Scale down reference app validation workloads

### DIFF
--- a/.github/scripts/collect_changed_templates.sh
+++ b/.github/scripts/collect_changed_templates.sh
@@ -58,8 +58,9 @@ for t in "${all_templates[@]}"; do
     mkdir -p "./$reference_apps_dir/.github/workflows"
     for workflow in fast-feedback extended-test prod; do
       if [[ -f "./$reference_apps_dir/$t/.github/workflows/$workflow.yaml" ]]; then
-        mv "./$reference_apps_dir/$t/.github/workflows/$workflow.yaml" \
-          "./$reference_apps_dir/.github/workflows/$t-$workflow.yaml"
+        workflow_file="./$reference_apps_dir/.github/workflows/$t-$workflow.yaml"
+        mv "./$reference_apps_dir/$t/.github/workflows/$workflow.yaml" "$workflow_file"
+        yq -i 'del(.on.schedule)' "$workflow_file"
       fi
     done
     rmdir "./$reference_apps_dir/$t/.github/workflows" 2>/dev/null || true

--- a/.github/workflows/docker-web-extended-test.yaml
+++ b/.github/workflows/docker-web-extended-test.yaml
@@ -1,15 +1,10 @@
 ---
 name: docker-web Extended Test
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 22 * * *"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: docker-web
       tenant-name: docker-web
-
   extendedtests:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1

--- a/.github/workflows/docker-web-fast-feedback.yaml
+++ b/.github/workflows/docker-web-fast-feedback.yaml
@@ -1,6 +1,5 @@
 ---
 name: docker-web Fast Feedback
-
 on:
   workflow_dispatch:
   push:
@@ -13,11 +12,9 @@ on:
       - main
     paths:
       - docker-web/**
-
 permissions:
   contents: write
   id-token: write
-
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/docker-web-prod.yaml
+++ b/.github/workflows/docker-web-prod.yaml
@@ -1,15 +1,10 @@
 ---
 name: docker-web Prod
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "30 5 * * 1-5"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: docker-web
       tenant-name: docker-web
-
   prod:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1

--- a/.github/workflows/go-web-extended-test.yaml
+++ b/.github/workflows/go-web-extended-test.yaml
@@ -1,15 +1,10 @@
 ---
 name: go-web Extended Test
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 22 * * *"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: go-web
       tenant-name: go-web
-
   extendedtests:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1

--- a/.github/workflows/go-web-fast-feedback.yaml
+++ b/.github/workflows/go-web-fast-feedback.yaml
@@ -1,6 +1,5 @@
 ---
 name: go-web Fast Feedback
-
 on:
   workflow_dispatch:
   push:
@@ -13,11 +12,9 @@ on:
       - main
     paths:
       - go-web/**
-
 permissions:
   contents: write
   id-token: write
-
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/go-web-prod.yaml
+++ b/.github/workflows/go-web-prod.yaml
@@ -1,15 +1,10 @@
 ---
 name: go-web Prod
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "30 5 * * 1-5"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: go-web
       tenant-name: go-web
-
   prod:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1

--- a/.github/workflows/infra-cloudsql-extended-test.yaml
+++ b/.github/workflows/infra-cloudsql-extended-test.yaml
@@ -1,15 +1,10 @@
 ---
 name: infra-cloudsql Extended Test
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 22 * * *"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: infra-cloudsql
       tenant-name: infra-cloudsql
-
   extendedtests:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1

--- a/.github/workflows/infra-cloudsql-fast-feedback.yaml
+++ b/.github/workflows/infra-cloudsql-fast-feedback.yaml
@@ -1,6 +1,5 @@
 ---
 name: infra-cloudsql Fast Feedback
-
 on:
   workflow_dispatch:
   push:
@@ -13,11 +12,9 @@ on:
       - main
     paths:
       - infra-cloudsql/**
-
 permissions:
   contents: write
   id-token: write
-
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/infra-cloudsql-prod.yaml
+++ b/.github/workflows/infra-cloudsql-prod.yaml
@@ -1,15 +1,10 @@
 ---
 name: infra-cloudsql Prod
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "30 5 * * 1-5"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: infra-cloudsql
       tenant-name: infra-cloudsql
-
   prod:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1

--- a/.github/workflows/infra-tofu-extended-test.yaml
+++ b/.github/workflows/infra-tofu-extended-test.yaml
@@ -1,15 +1,10 @@
 ---
 name: infra-tofu Extended Test
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 22 * * *"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: infra-tofu
       tenant-name: infra-tofu
-
   extendedtests:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1

--- a/.github/workflows/infra-tofu-fast-feedback.yaml
+++ b/.github/workflows/infra-tofu-fast-feedback.yaml
@@ -1,6 +1,5 @@
 ---
 name: infra-tofu Fast Feedback
-
 on:
   workflow_dispatch:
   push:
@@ -13,11 +12,9 @@ on:
       - main
     paths:
       - infra-tofu/**
-
 permissions:
   contents: write
   id-token: write
-
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/infra-tofu-prod.yaml
+++ b/.github/workflows/infra-tofu-prod.yaml
@@ -1,15 +1,10 @@
 ---
 name: infra-tofu Prod
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "30 5 * * 1-5"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: infra-tofu
       tenant-name: infra-tofu
-
   prod:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1

--- a/.github/workflows/infra-urlrouter-extended-test.yaml
+++ b/.github/workflows/infra-urlrouter-extended-test.yaml
@@ -1,15 +1,10 @@
 ---
 name: infra-urlrouter Extended Test
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 22 * * *"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: infra-urlrouter
       tenant-name: infra-urlrouter
-
   extendedtests:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1

--- a/.github/workflows/infra-urlrouter-fast-feedback.yaml
+++ b/.github/workflows/infra-urlrouter-fast-feedback.yaml
@@ -1,6 +1,5 @@
 ---
 name: infra-urlrouter Fast Feedback
-
 on:
   workflow_dispatch:
   push:
@@ -13,11 +12,9 @@ on:
       - main
     paths:
       - infra-urlrouter/**
-
 permissions:
   contents: write
   id-token: write
-
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/infra-urlrouter-prod.yaml
+++ b/.github/workflows/infra-urlrouter-prod.yaml
@@ -1,15 +1,10 @@
 ---
 name: infra-urlrouter Prod
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "30 5 * * 1-5"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: infra-urlrouter
       tenant-name: infra-urlrouter
-
   prod:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1

--- a/.github/workflows/java-web-extended-test.yaml
+++ b/.github/workflows/java-web-extended-test.yaml
@@ -1,15 +1,10 @@
 ---
 name: java-web Extended Test
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 22 * * *"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: java-web
       tenant-name: java-web
-
   extendedtests:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1

--- a/.github/workflows/java-web-fast-feedback.yaml
+++ b/.github/workflows/java-web-fast-feedback.yaml
@@ -1,6 +1,5 @@
 ---
 name: java-web Fast Feedback
-
 on:
   workflow_dispatch:
   push:
@@ -13,11 +12,9 @@ on:
       - main
     paths:
       - java-web/**
-
 permissions:
   contents: write
   id-token: write
-
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/java-web-prod.yaml
+++ b/.github/workflows/java-web-prod.yaml
@@ -1,15 +1,10 @@
 ---
 name: java-web Prod
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "30 5 * * 1-5"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: java-web
       tenant-name: java-web
-
   prod:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1

--- a/.github/workflows/nextjs-web-extended-test.yaml
+++ b/.github/workflows/nextjs-web-extended-test.yaml
@@ -1,15 +1,10 @@
 ---
 name: nextjs-web Extended Test
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 22 * * *"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: nextjs-web
       tenant-name: nextjs-web
-
   extendedtests:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1

--- a/.github/workflows/nextjs-web-fast-feedback.yaml
+++ b/.github/workflows/nextjs-web-fast-feedback.yaml
@@ -1,6 +1,5 @@
 ---
 name: nextjs-web Fast Feedback
-
 on:
   workflow_dispatch:
   push:
@@ -13,11 +12,9 @@ on:
       - main
     paths:
       - nextjs-web/**
-
 permissions:
   contents: write
   id-token: write
-
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/nextjs-web-prod.yaml
+++ b/.github/workflows/nextjs-web-prod.yaml
@@ -1,15 +1,10 @@
 ---
 name: nextjs-web Prod
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "30 5 * * 1-5"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: nextjs-web
       tenant-name: nextjs-web
-
   prod:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1

--- a/.github/workflows/python-web-extended-test.yaml
+++ b/.github/workflows/python-web-extended-test.yaml
@@ -1,15 +1,10 @@
 ---
 name: python-web Extended Test
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 22 * * *"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: python-web
       tenant-name: python-web
-
   extendedtests:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1

--- a/.github/workflows/python-web-fast-feedback.yaml
+++ b/.github/workflows/python-web-fast-feedback.yaml
@@ -1,6 +1,5 @@
 ---
 name: python-web Fast Feedback
-
 on:
   workflow_dispatch:
   push:
@@ -13,11 +12,9 @@ on:
       - main
     paths:
       - python-web/**
-
 permissions:
   contents: write
   id-token: write
-
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/python-web-prod.yaml
+++ b/.github/workflows/python-web-prod.yaml
@@ -1,15 +1,10 @@
 ---
 name: python-web Prod
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "30 5 * * 1-5"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: python-web
       tenant-name: python-web
-
   prod:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1

--- a/.github/workflows/render-templates.yaml
+++ b/.github/workflows/render-templates.yaml
@@ -118,3 +118,94 @@ jobs:
           dispatch_and_wait "$APP-fast-feedback.yaml"
           dispatch_and_wait "$APP-extended-test.yaml"
           dispatch_and_wait "$APP-prod.yaml"
+
+  cleanup-matrix:
+    needs: [update-templates]
+    if: needs.update-templates.outputs.changed_templates != '[]'
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - id: matrix
+        env:
+          CHANGED_TEMPLATES: ${{ needs.update-templates.outputs.changed_templates }}
+          FAST_FEEDBACK: ${{ vars.FAST_FEEDBACK }}
+          PROD: ${{ vars.PROD }}
+        run: |
+          set -euo pipefail
+          matrix="$(jq -cn \
+            --argjson apps "$CHANGED_TEMPLATES" \
+            --argjson fast_feedback "$FAST_FEEDBACK" \
+            --argjson prod "$PROD" \
+            '{include: (
+              [$apps[] as $app | $fast_feedback[] | {app: $app, stage: "integration", deploy_env: .deploy_env}] +
+              [$apps[] as $app | $prod[] | {app: $app, stage: "prod", deploy_env: .deploy_env}]
+            )}')"
+          echo "Cleanup matrix: $matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  cleanup:
+    needs: [update-templates, p2p, cleanup-matrix]
+    if: always() && needs.update-templates.result == 'success' && needs.cleanup-matrix.result == 'success' && needs.update-templates.outputs.changed_templates != '[]'
+    runs-on: ubuntu-24.04
+    environment: ${{ matrix.deploy_env }}
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.cleanup-matrix.outputs.matrix) }}
+    env:
+      APP: ${{ matrix.app }}
+      STAGE: ${{ matrix.stage }}
+      DPLATFORM: ${{ vars.DPLATFORM }}
+      PROJECT_ID: ${{ vars.PROJECT_ID }}
+      PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER }}
+      REGION: ${{ vars.REGION || 'europe-west2' }}
+      SERVICE_ACCOUNT: p2p-${{ matrix.app }}@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com
+      WORKLOAD_IDENTITY_PROVIDER: projects/${{ vars.PROJECT_NUMBER }}/locations/global/workloadIdentityPools/p2p-${{ matrix.app }}/providers/p2p-${{ matrix.app }}
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+          project_id: ${{ env.PROJECT_ID }}
+          token_format: access_token
+          access_token_lifetime: 3600s
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          skip_install: true
+
+      - name: Setup kubeconfig
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          context_name: gke_${{ env.PROJECT_ID }}_${{ env.REGION }}_${{ env.DPLATFORM }}
+          cluster_name: ${{ env.DPLATFORM }}
+          location: ${{ env.REGION }}
+          project_id: ${{ env.PROJECT_ID }}
+          use_dns_based_endpoint: true
+
+      - name: Scale down reference app namespace
+        run: |
+          set -euo pipefail
+          namespace="$APP-$STAGE"
+
+          if ! kubectl get namespace "$namespace" >/dev/null 2>&1; then
+            echo "Namespace $namespace does not exist; nothing to scale down"
+            exit 0
+          fi
+
+          echo "Deleting HPAs in $namespace"
+          kubectl -n "$namespace" delete hpa --all --ignore-not-found
+
+          resources="$(kubectl -n "$namespace" get deployments,statefulsets -o name 2>/dev/null || true)"
+          if [[ -z "$resources" ]]; then
+            echo "No deployments or statefulsets found in $namespace"
+            exit 0
+          fi
+
+          echo "Scaling workloads in $namespace to zero"
+          kubectl -n "$namespace" scale --replicas=0 $resources

--- a/.github/workflows/static-nextra-extended-test.yaml
+++ b/.github/workflows/static-nextra-extended-test.yaml
@@ -1,15 +1,10 @@
 ---
 name: static-nextra Extended Test
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 22 * * *"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: static-nextra
       tenant-name: static-nextra
-
   extendedtests:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1

--- a/.github/workflows/static-nextra-fast-feedback.yaml
+++ b/.github/workflows/static-nextra-fast-feedback.yaml
@@ -1,6 +1,5 @@
 ---
 name: static-nextra Fast Feedback
-
 on:
   workflow_dispatch:
   push:
@@ -13,11 +12,9 @@ on:
       - main
     paths:
       - static-nextra/**
-
 permissions:
   contents: write
   id-token: write
-
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/static-nextra-prod.yaml
+++ b/.github/workflows/static-nextra-prod.yaml
@@ -1,15 +1,10 @@
 ---
 name: static-nextra Prod
-
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "30 5 * * 1-5"
-
 permissions:
   contents: read
   id-token: write
-
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
@@ -18,7 +13,6 @@ jobs:
     with:
       image-name: static-nextra
       tenant-name: static-nextra
-
   prod:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1


### PR DESCRIPTION
## Summary
- Remove scheduled triggers from generated reference app workflows while keeping manual dispatch intact.
- Strip schedules from promoted workflows during template rendering so future template schedules do not reappear in this repo.
- Scale integration and prod reference app workloads to zero after render-triggered validation by deleting HPAs first, then scaling deployments/statefulsets.

## Validation
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yaml"].each { |f| YAML.load_file(f) }; puts "YAML parse OK"'`
- `bash -n .github/scripts/collect_changed_templates.sh`
- `git diff --check`
- Verified no `schedule:` or `cron:` entries remain in `.github/workflows/*.yaml`.
- Verified 27 expected app workflow names remain present.