### PR TITLE
Fix reference app cleanup matrix

### DIFF
--- a/.github/workflows/render-templates.yaml
+++ b/.github/workflows/render-templates.yaml
@@ -138,8 +138,8 @@ jobs:
             --argjson fast_feedback "$FAST_FEEDBACK" \
             --argjson prod "$PROD" \
             '{include: (
-              [$apps[] as $app | $fast_feedback[] | {app: $app, stage: "integration", deploy_env: .deploy_env}] +
-              [$apps[] as $app | $prod[] | {app: $app, stage: "prod", deploy_env: .deploy_env}]
+              [$apps[] as $app | $fast_feedback.include[] | {app: $app, stage: "integration", deploy_env: .deploy_env}] +
+              [$apps[] as $app | $prod.include[] | {app: $app, stage: "prod", deploy_env: .deploy_env}]
             )}')"
           echo "Cleanup matrix: $matrix"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fix cleanup matrix generation to read `deploy_env` from the `include` arrays in `FAST_FEEDBACK` and `PROD` vars.
- Preserve the existing integration/prod cleanup matrix shape while matching the actual vars JSON.

## Validation
- Reproduced matrix generation locally with the failed run's exact `CHANGED_TEMPLATES`, `FAST_FEEDBACK`, and `PROD` values.
- Verified the generated cleanup matrix contains 18 entries for 9 apps across integration and prod.
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yaml"].each { |f| YAML.load_file(f) }; puts "YAML parse OK"'`
- `bash -n .github/scripts/collect_changed_templates.sh`
- `git diff --check`