### PR TITLE
Skip subnamespace creation for infra references

### DIFF
--- a/.github/workflows/reference-infra-cloudsql-extended-test.yaml
+++ b/.github/workflows/reference-infra-cloudsql-extended-test.yaml
@@ -24,4 +24,5 @@ jobs:
       tenant-name: reference-infra-cloudsql
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: reference-infra-cloudsql/v
+      skip-subnamespaces-create: true
       working-directory: reference-infra-cloudsql

--- a/.github/workflows/reference-infra-cloudsql-fast-feedback.yaml
+++ b/.github/workflows/reference-infra-cloudsql-fast-feedback.yaml
@@ -33,4 +33,5 @@ jobs:
       app-name: reference-infra-cloudsql
       tenant-name: reference-infra-cloudsql
       version: ${{ needs.version.outputs.version }}
+      skip-subnamespaces-create: true
       working-directory: reference-infra-cloudsql

--- a/.github/workflows/reference-infra-cloudsql-prod.yaml
+++ b/.github/workflows/reference-infra-cloudsql-prod.yaml
@@ -24,4 +24,5 @@ jobs:
       tenant-name: reference-infra-cloudsql
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: reference-infra-cloudsql/v
+      skip-subnamespaces-create: true
       working-directory: reference-infra-cloudsql

--- a/.github/workflows/reference-infra-tofu-extended-test.yaml
+++ b/.github/workflows/reference-infra-tofu-extended-test.yaml
@@ -24,4 +24,5 @@ jobs:
       tenant-name: reference-infra-tofu
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: reference-infra-tofu/v
+      skip-subnamespaces-create: true
       working-directory: reference-infra-tofu

--- a/.github/workflows/reference-infra-tofu-fast-feedback.yaml
+++ b/.github/workflows/reference-infra-tofu-fast-feedback.yaml
@@ -33,4 +33,5 @@ jobs:
       app-name: reference-infra-tofu
       tenant-name: reference-infra-tofu
       version: ${{ needs.version.outputs.version }}
+      skip-subnamespaces-create: true
       working-directory: reference-infra-tofu

--- a/.github/workflows/reference-infra-tofu-prod.yaml
+++ b/.github/workflows/reference-infra-tofu-prod.yaml
@@ -24,4 +24,5 @@ jobs:
       tenant-name: reference-infra-tofu
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: reference-infra-tofu/v
+      skip-subnamespaces-create: true
       working-directory: reference-infra-tofu

--- a/.github/workflows/reference-infra-urlrouter-extended-test.yaml
+++ b/.github/workflows/reference-infra-urlrouter-extended-test.yaml
@@ -24,4 +24,5 @@ jobs:
       tenant-name: reference-infra-urlrouter
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: reference-infra-urlrouter/v
+      skip-subnamespaces-create: true
       working-directory: reference-infra-urlrouter

--- a/.github/workflows/reference-infra-urlrouter-fast-feedback.yaml
+++ b/.github/workflows/reference-infra-urlrouter-fast-feedback.yaml
@@ -33,4 +33,5 @@ jobs:
       app-name: reference-infra-urlrouter
       tenant-name: reference-infra-urlrouter
       version: ${{ needs.version.outputs.version }}
+      skip-subnamespaces-create: true
       working-directory: reference-infra-urlrouter

--- a/.github/workflows/reference-infra-urlrouter-prod.yaml
+++ b/.github/workflows/reference-infra-urlrouter-prod.yaml
@@ -24,4 +24,5 @@ jobs:
       tenant-name: reference-infra-urlrouter
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: reference-infra-urlrouter/v
+      skip-subnamespaces-create: true
       working-directory: reference-infra-urlrouter


### PR DESCRIPTION
## Summary
- Add skip-subnamespaces-create: true to the rendered infra reference fast feedback workflows
- Add skip-subnamespaces-create: true to the rendered infra reference extended test and prod workflows

## Testing
- Ran git diff --check