### PR TITLE
Add Cloud SQL IDS compliance resources

### DIFF
--- a/reference-infra-cloudsql/infrastructure/code/cloudsql.tf
+++ b/reference-infra-cloudsql/infrastructure/code/cloudsql.tf
@@ -13,6 +13,13 @@ variable "cloudsql" {
         write_ops_per_second = optional(number, 1000)
       }), {})
     }), {})
+    ids = optional(object({
+      enabled               = optional(bool, true)
+      location              = optional(string)
+      severity              = optional(string, "INFORMATIONAL")
+      packet_mirroring_tags = optional(list(string), ["cloudsql-psa"])
+      notifications_enabled = optional(bool, true)
+    }), {})
     clusters = optional(object({
       postgresql = optional(list(object({
         name               = string
@@ -78,6 +85,11 @@ variable "cloudsql" {
       })))
     }))
   })
+
+  validation {
+    condition     = contains(["INFORMATIONAL", "LOW", "MEDIUM"], try(var.cloudsql.ids.severity, "INFORMATIONAL"))
+    error_message = "cloudsql.ids.severity must be INFORMATIONAL, LOW, or MEDIUM."
+  }
 }
 
 module "cloudsql" {

--- a/reference-infra-cloudsql/infrastructure/code/modules/cloudsql/apis.tf
+++ b/reference-infra-cloudsql/infrastructure/code/modules/cloudsql/apis.tf
@@ -10,6 +10,8 @@ module "project-services" {
   activate_apis = [
     "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",
+    "ids.googleapis.com",
+    "logging.googleapis.com",
     "sqladmin.googleapis.com",
     "servicenetworking.googleapis.com",
   ]

--- a/reference-infra-cloudsql/infrastructure/code/modules/cloudsql/cloud_ids.tf
+++ b/reference-infra-cloudsql/infrastructure/code/modules/cloudsql/cloud_ids.tf
@@ -1,0 +1,85 @@
+resource "google_cloud_ids_endpoint" "psa" {
+  count = local.cloud_ids_enabled ? 1 : 0
+
+  project  = var.infrastructure_project_id
+  name     = "cloudsql-${var.environment}-ids"
+  location = local.cloud_ids_location
+  network  = google_compute_network.psa.id
+  severity = local.cloud_ids_severity
+
+  depends_on = [module.project-services, module.cloudsql-psa]
+}
+
+resource "google_compute_packet_mirroring" "psa" {
+  count = local.cloud_ids_enabled ? 1 : 0
+
+  project = var.infrastructure_project_id
+  region  = var.region
+  name    = "cloudsql-${var.environment}-ids-mirroring"
+
+  network {
+    url = google_compute_network.psa.id
+  }
+
+  collector_ilb {
+    url = google_cloud_ids_endpoint.psa[0].endpoint_forwarding_rule
+  }
+
+  mirrored_resources {
+    tags = local.cloud_ids_packet_mirroring_tags
+  }
+
+  filter {
+    direction   = "BOTH"
+    cidr_ranges = ["0.0.0.0/0"]
+  }
+}
+
+resource "google_logging_metric" "cloud_ids_threat_detections" {
+  count = local.cloud_ids_enabled && local.cloud_ids_notifications_enabled ? 1 : 0
+
+  project = var.infrastructure_project_id
+  name    = "cloud_ids_${var.environment}_threat_detections"
+  filter  = "resource.type=\"ids.googleapis.com/Endpoint\""
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+  }
+
+  depends_on = [module.project-services]
+}
+
+resource "google_monitoring_alert_policy" "cloud_ids_threat_detections" {
+  count = local.cloud_ids_enabled && local.cloud_ids_notifications_enabled && length(var.cloudsql.monitoring.notification_emails) > 0 ? 1 : 0
+
+  project               = var.infrastructure_project_id
+  display_name          = "Cloud IDS threat detections - cloudsql-${var.environment}-psa"
+  combiner              = "OR"
+  enabled               = true
+  notification_channels = local.cloudsql_notification_channels
+
+  conditions {
+    display_name = "Cloud IDS endpoint threat detection logs"
+
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.cloud_ids_threat_detections[0].name}\""
+      comparison      = "COMPARISON_GT"
+      duration        = "0s"
+      threshold_value = 0
+
+      aggregations {
+        alignment_period     = "60s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  depends_on = [google_project_service.monitoring]
+}

--- a/reference-infra-cloudsql/infrastructure/code/modules/cloudsql/locals.tf
+++ b/reference-infra-cloudsql/infrastructure/code/modules/cloudsql/locals.tf
@@ -46,6 +46,12 @@ locals {
     for channel in google_monitoring_notification_channel.cloudsql_email : channel.name
   ]
 
+  cloud_ids_enabled               = try(var.cloudsql.ids.enabled, true)
+  cloud_ids_location              = coalesce(try(var.cloudsql.ids.location, null), "${var.region}-b")
+  cloud_ids_severity              = try(var.cloudsql.ids.severity, "INFORMATIONAL")
+  cloud_ids_packet_mirroring_tags = try(var.cloudsql.ids.packet_mirroring_tags, ["cloudsql-psa"])
+  cloud_ids_notifications_enabled = try(var.cloudsql.ids.notifications_enabled, true)
+
   cloudsql_alert_metrics = {
     cpu_utilization = {
       display_name       = "CPU utilization"

--- a/reference-infra-cloudsql/infrastructure/code/modules/cloudsql/variables.tf
+++ b/reference-infra-cloudsql/infrastructure/code/modules/cloudsql/variables.tf
@@ -29,6 +29,13 @@ variable "cloudsql" {
         write_ops_per_second = optional(number, 1000)
       }), {})
     }), {})
+    ids = optional(object({
+      enabled               = optional(bool, true)
+      location              = optional(string)
+      severity              = optional(string, "INFORMATIONAL")
+      packet_mirroring_tags = optional(list(string), ["cloudsql-psa"])
+      notifications_enabled = optional(bool, true)
+    }), {})
     clusters = optional(object({
       postgresql = optional(list(object({
         name               = string
@@ -94,4 +101,9 @@ variable "cloudsql" {
       })))
     }))
   })
+
+  validation {
+    condition     = contains(["INFORMATIONAL", "LOW", "MEDIUM"], try(var.cloudsql.ids.severity, "INFORMATIONAL"))
+    error_message = "cloudsql.ids.severity must be INFORMATIONAL, LOW, or MEDIUM."
+  }
 }


### PR DESCRIPTION
## Summary\n- add optional Cloud IDS configuration to the reference Cloud SQL module\n- enable IDS and Logging APIs for Cloud SQL infra projects\n- create a Cloud IDS endpoint for the Cloud SQL PSA VPC\n- attach tag-based packet mirroring without adding dummy subnets or VMs\n- add a logs-based Cloud IDS threat detection metric and notification-backed alert policy\n\n## Validation\n- tofu fmt -recursive\n- tofu init -backend=false -input=false\n- tofu validate\n\n## Notes\nReference app update for parity with the Cloud SQL software template.