### PR TITLE
Update reference workflows for security scanning

### DIFF
--- a/.github/scripts/collect_changed_templates.sh
+++ b/.github/scripts/collect_changed_templates.sh
@@ -57,7 +57,7 @@ for t in "${all_templates[@]}"; do
 
   if [[ -d "./$reference_apps_dir/$reference_t/.github/workflows" ]]; then
     mkdir -p "./$reference_apps_dir/.github/workflows"
-    for workflow in fast-feedback extended-test prod; do
+    for workflow in fast-feedback extended-test prod scheduled-security-scan; do
       if [[ -f "./$reference_apps_dir/$reference_t/.github/workflows/$workflow.yaml" ]]; then
         workflow_file="./$reference_apps_dir/.github/workflows/$reference_t-$workflow.yaml"
         mv "./$reference_apps_dir/$reference_t/.github/workflows/$workflow.yaml" "$workflow_file"
@@ -71,7 +71,8 @@ for t in "${all_templates[@]}"; do
   git -C "./$reference_apps_dir" add "./$reference_t"
   git -C "./$reference_apps_dir" add "./.github/workflows/$reference_t-fast-feedback.yaml" \
     "./.github/workflows/$reference_t-extended-test.yaml" \
-    "./.github/workflows/$reference_t-prod.yaml"
+    "./.github/workflows/$reference_t-prod.yaml" \
+    "./.github/workflows/$reference_t-scheduled-security-scan.yaml"
   if [[ "$(git -C "$reference_apps_dir" status "./$reference_t" --untracked-files=no --porcelain)" ]]; then
     echo "Template '$t' has changed!"
     changed_templates+=("$t")
@@ -79,6 +80,7 @@ for t in "${all_templates[@]}"; do
     "./.github/workflows/$reference_t-fast-feedback.yaml" \
     "./.github/workflows/$reference_t-extended-test.yaml" \
     "./.github/workflows/$reference_t-prod.yaml" \
+    "./.github/workflows/$reference_t-scheduled-security-scan.yaml" \
     --untracked-files=no --porcelain)" ]]; then
     echo "Template '$t' workflows have changed!"
     changed_templates+=("$t")

--- a/.github/workflows/reference-docker-web-fast-feedback.yaml
+++ b/.github/workflows/reference-docker-web-fast-feedback.yaml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/reference-docker-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-docker-web-scheduled-security-scan.yaml
@@ -1,0 +1,16 @@
+---
+name: reference-docker-web Security Scan
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: ${{ secrets.env_vars }}
+    with:
+      tenant-name: reference-docker-web
+      security-scan-blocking-severity: "off"
+      working-directory: reference-docker-web

--- a/.github/workflows/reference-go-web-fast-feedback.yaml
+++ b/.github/workflows/reference-go-web-fast-feedback.yaml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/reference-go-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-go-web-scheduled-security-scan.yaml
@@ -1,0 +1,16 @@
+---
+name: reference-go-web Security Scan
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: ${{ secrets.env_vars }}
+    with:
+      tenant-name: reference-go-web
+      security-scan-blocking-severity: "off"
+      working-directory: reference-go-web

--- a/.github/workflows/reference-infra-cloudsql-fast-feedback.yaml
+++ b/.github/workflows/reference-infra-cloudsql-fast-feedback.yaml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/reference-infra-cloudsql-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-infra-cloudsql-scheduled-security-scan.yaml
@@ -1,0 +1,16 @@
+---
+name: reference-infra-cloudsql Security Scan
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: ${{ secrets.env_vars }}
+    with:
+      tenant-name: reference-infra-cloudsql
+      security-scan-blocking-severity: "off"
+      working-directory: reference-infra-cloudsql

--- a/.github/workflows/reference-infra-tofu-fast-feedback.yaml
+++ b/.github/workflows/reference-infra-tofu-fast-feedback.yaml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/reference-infra-tofu-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-infra-tofu-scheduled-security-scan.yaml
@@ -1,0 +1,16 @@
+---
+name: reference-infra-tofu Security Scan
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: ${{ secrets.env_vars }}
+    with:
+      tenant-name: reference-infra-tofu
+      security-scan-blocking-severity: "off"
+      working-directory: reference-infra-tofu

--- a/.github/workflows/reference-infra-urlrouter-fast-feedback.yaml
+++ b/.github/workflows/reference-infra-urlrouter-fast-feedback.yaml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/reference-infra-urlrouter-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-infra-urlrouter-scheduled-security-scan.yaml
@@ -1,0 +1,16 @@
+---
+name: reference-infra-urlrouter Security Scan
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: ${{ secrets.env_vars }}
+    with:
+      tenant-name: reference-infra-urlrouter
+      security-scan-blocking-severity: "off"
+      working-directory: reference-infra-urlrouter

--- a/.github/workflows/reference-java-web-fast-feedback.yaml
+++ b/.github/workflows/reference-java-web-fast-feedback.yaml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/reference-java-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-java-web-scheduled-security-scan.yaml
@@ -1,0 +1,16 @@
+---
+name: reference-java-web Security Scan
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: ${{ secrets.env_vars }}
+    with:
+      tenant-name: reference-java-web
+      security-scan-blocking-severity: "off"
+      working-directory: reference-java-web

--- a/.github/workflows/reference-nextjs-web-fast-feedback.yaml
+++ b/.github/workflows/reference-nextjs-web-fast-feedback.yaml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/reference-nextjs-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-nextjs-web-scheduled-security-scan.yaml
@@ -1,0 +1,16 @@
+---
+name: reference-nextjs-web Security Scan
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: ${{ secrets.env_vars }}
+    with:
+      tenant-name: reference-nextjs-web
+      security-scan-blocking-severity: "off"
+      working-directory: reference-nextjs-web

--- a/.github/workflows/reference-python-web-fast-feedback.yaml
+++ b/.github/workflows/reference-python-web-fast-feedback.yaml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/reference-python-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-python-web-scheduled-security-scan.yaml
@@ -1,0 +1,16 @@
+---
+name: reference-python-web Security Scan
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: ${{ secrets.env_vars }}
+    with:
+      tenant-name: reference-python-web
+      security-scan-blocking-severity: "off"
+      working-directory: reference-python-web

--- a/.github/workflows/reference-static-nextra-fast-feedback.yaml
+++ b/.github/workflows/reference-static-nextra-fast-feedback.yaml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 jobs:
   version:
     uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1

--- a/.github/workflows/reference-static-nextra-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-static-nextra-scheduled-security-scan.yaml
@@ -1,0 +1,16 @@
+---
+name: reference-static-nextra Security Scan
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: ${{ secrets.env_vars }}
+    with:
+      tenant-name: reference-static-nextra
+      security-scan-blocking-severity: "off"
+      working-directory: reference-static-nextra

--- a/.github/workflows/render-templates.yaml
+++ b/.github/workflows/render-templates.yaml
@@ -31,7 +31,8 @@ jobs:
           out-file-path: corectl
       - id: render
         run: |
-          export PATH="${PATH}:$(realpath ./corectl)"
+          corectl_path="$(realpath ./corectl)"
+          export PATH="${PATH}:${corectl_path}"
           ./reference-apps/.github/scripts/collect_changed_templates.sh \
             -t ./software-templates \
             -r ./reference-apps \
@@ -39,7 +40,7 @@ jobs:
             -a ./reference-apps/.github/data/args.yaml
           ct_json="$(cat ./changed_templates.json)"
           echo "Changed templates: $ct_json"
-          echo "changed_templates=$ct_json" >> $GITHUB_OUTPUT
+          echo "changed_templates=$ct_json" >> "$GITHUB_OUTPUT"
           git -C "./reference-apps" status --porcelain
       - uses: stefanzweifel/git-auto-commit-action@v7
         id: push


### PR DESCRIPTION
## Summary
- add generated scheduled security scan workflows for all reference applications
- add pull-requests: write to generated fast-feedback workflows
- update the template render script to move, stage, and detect scheduled-security-scan workflows on future renders
- keep generated security scan workflows dispatch-only by retaining the existing schedule-removal behavior

## Validation
- bash -n .github/scripts/collect_changed_templates.sh
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yaml"].each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'
- actionlint .github/workflows/reference-*-fast-feedback.yaml .github/workflows/reference-*-scheduled-security-scan.yaml .github/workflows/render-templates.yaml