### PR TITLE
Rollback Terragrunt version

### DIFF
--- a/reference-infra-cloudsql/infrastructure/code/terragrunt.hcl
+++ b/reference-infra-cloudsql/infrastructure/code/terragrunt.hcl
@@ -18,8 +18,11 @@ locals {
   ])
 }
 
-# Skip execution if required configuration is missing
-skip = !local.has_required_config
+# Exclude from Terragrunt run queues if required configuration is missing
+exclude {
+  if      = !local.has_required_config
+  actions = ["all"]
+}
 
 inputs = {
   p2p_version               = local.p2p_version

--- a/reference-infra-tofu/infrastructure/code/terragrunt.hcl
+++ b/reference-infra-tofu/infrastructure/code/terragrunt.hcl
@@ -18,8 +18,11 @@ locals {
   ])
 }
 
-# Skip execution if required configuration is missing
-skip = !local.has_required_config
+# Exclude from Terragrunt run queues if required configuration is missing
+exclude {
+  if      = !local.has_required_config
+  actions = ["all"]
+}
 
 inputs = {
   p2p_version               = local.p2p_version

--- a/reference-infra-urlrouter/infrastructure/code/terragrunt.hcl
+++ b/reference-infra-urlrouter/infrastructure/code/terragrunt.hcl
@@ -18,8 +18,11 @@ locals {
   ])
 }
 
-# Skip execution if required configuration is missing
-skip = !local.has_required_config
+# Exclude from Terragrunt run queues if required configuration is missing
+exclude {
+  if      = !local.has_required_config
+  actions = ["all"]
+}
 
 inputs = {
   p2p_version               = local.p2p_version


### PR DESCRIPTION
## Summary
- roll back infra reference app Terragrunt from `1.0.8` to `0.92.1`
- keep existing `skip` behavior for missing infra config instead of migrating to `exclude`

## Why
Terragrunt `1.0.8` removed the `skip` attribute. Replacing it with `exclude` validates, but direct `terragrunt apply --working-dir=...` still runs and fails on missing GCS remote state config. Rolling back Terragrunt preserves the current direct-apply skip behavior.

## Verification
- `terragrunt 0.92.1 hcl validate` for reference-infra-tofu
- `terragrunt 0.92.1 hcl validate` for reference-infra-urlrouter
- `terragrunt 0.92.1 hcl validate` for reference-infra-cloudsql
- direct `terragrunt 0.92.1 apply` probe with missing config and OpenTofu `1.12.3` logs `Skipping terragrunt module ... due to skip = true`
- `git diff --check origin/main`