### PR TITLE
Run security scan after rendered workflows

### DIFF
--- a/.github/workflows/render-templates.yaml
+++ b/.github/workflows/render-templates.yaml
@@ -119,6 +119,7 @@ jobs:
           dispatch_and_wait "reference-$APP-fast-feedback.yaml"
           dispatch_and_wait "reference-$APP-extended-test.yaml"
           dispatch_and_wait "reference-$APP-prod.yaml"
+          dispatch_and_wait "reference-$APP-scheduled-security-scan.yaml"
 
   cleanup-matrix:
     needs: [update-templates]


### PR DESCRIPTION
## Summary
- dispatch the scheduled security scan workflow after fast feedback, extended test, and prod workflows in the render workflow

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/render-templates.yaml"); puts "YAML OK"'