### PR TITLE
Fix security scan workflow schedules

### DIFF
--- a/.github/scripts/collect_changed_templates.sh
+++ b/.github/scripts/collect_changed_templates.sh
@@ -61,7 +61,9 @@ for t in "${all_templates[@]}"; do
       if [[ -f "./$reference_apps_dir/$reference_t/.github/workflows/$workflow.yaml" ]]; then
         workflow_file="./$reference_apps_dir/.github/workflows/$reference_t-$workflow.yaml"
         mv "./$reference_apps_dir/$reference_t/.github/workflows/$workflow.yaml" "$workflow_file"
-        yq -i 'del(.on.schedule)' "$workflow_file"
+        if [[ "$workflow" != "scheduled-security-scan" ]]; then
+          yq -i 'del(.on.schedule)' "$workflow_file"
+        fi
       fi
     done
     rmdir "./$reference_apps_dir/$reference_t/.github/workflows" 2>/dev/null || true

--- a/.github/workflows/reference-docker-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-docker-web-scheduled-security-scan.yaml
@@ -2,6 +2,8 @@
 name: reference-docker-web Security Scan
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/reference-go-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-go-web-scheduled-security-scan.yaml
@@ -2,6 +2,8 @@
 name: reference-go-web Security Scan
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/reference-infra-cloudsql-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-infra-cloudsql-scheduled-security-scan.yaml
@@ -2,6 +2,8 @@
 name: reference-infra-cloudsql Security Scan
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/reference-infra-tofu-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-infra-tofu-scheduled-security-scan.yaml
@@ -2,6 +2,8 @@
 name: reference-infra-tofu Security Scan
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/reference-infra-urlrouter-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-infra-urlrouter-scheduled-security-scan.yaml
@@ -2,6 +2,8 @@
 name: reference-infra-urlrouter Security Scan
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/reference-java-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-java-web-scheduled-security-scan.yaml
@@ -2,6 +2,8 @@
 name: reference-java-web Security Scan
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/reference-nextjs-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-nextjs-web-scheduled-security-scan.yaml
@@ -2,6 +2,8 @@
 name: reference-nextjs-web Security Scan
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/reference-python-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-python-web-scheduled-security-scan.yaml
@@ -2,6 +2,8 @@
 name: reference-python-web Security Scan
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/reference-static-nextra-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-static-nextra-scheduled-security-scan.yaml
@@ -2,6 +2,8 @@
 name: reference-static-nextra Security Scan
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
## Summary
- Preserve schedules when rendering scheduled security scan workflows
- Restore the 04:00 UTC cron schedule on generated reference security scan workflows
- Keep schedule stripping for other rendered workflows unchanged

## Validation
- bash -n .github/scripts/collect_changed_templates.sh
- yq eval '.on.schedule' .github/workflows/reference-*-scheduled-security-scan.yaml