### PR TITLE
Normalize rendered security scan workflows

### DIFF
--- a/.github/scripts/collect_changed_templates.sh
+++ b/.github/scripts/collect_changed_templates.sh
@@ -61,7 +61,9 @@ for t in "${all_templates[@]}"; do
       if [[ -f "./$reference_apps_dir/$reference_t/.github/workflows/$workflow.yaml" ]]; then
         workflow_file="./$reference_apps_dir/.github/workflows/$reference_t-$workflow.yaml"
         mv "./$reference_apps_dir/$reference_t/.github/workflows/$workflow.yaml" "$workflow_file"
-        if [[ "$workflow" != "scheduled-security-scan" ]]; then
+        if [[ "$workflow" == "scheduled-security-scan" ]]; then
+          yq -i '.' "$workflow_file"
+        else
           yq -i 'del(.on.schedule)' "$workflow_file"
         fi
       fi


### PR DESCRIPTION
## Summary
- normalize scheduled security scan workflow YAML after rendering
- preserve the scheduled security scan `on.schedule` entry
- avoid workflow-file diffs caused only by blank-line formatting

## Testing
- bash -n .github/scripts/collect_changed_templates.sh
- git diff --check