### PR TITLE
Add app name to security scans

### DIFF
--- a/.github/workflows/reference-docker-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-docker-web-scheduled-security-scan.yaml
@@ -13,6 +13,7 @@ jobs:
     secrets:
       env_vars: ${{ secrets.env_vars }}
     with:
+      app-name: reference-docker-web
       tenant-name: reference-docker-web
       security-scan-blocking-severity: "off"
       working-directory: reference-docker-web

--- a/.github/workflows/reference-go-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-go-web-scheduled-security-scan.yaml
@@ -13,6 +13,7 @@ jobs:
     secrets:
       env_vars: ${{ secrets.env_vars }}
     with:
+      app-name: reference-go-web
       tenant-name: reference-go-web
       security-scan-blocking-severity: "off"
       working-directory: reference-go-web

--- a/.github/workflows/reference-infra-cloudsql-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-infra-cloudsql-scheduled-security-scan.yaml
@@ -13,6 +13,7 @@ jobs:
     secrets:
       env_vars: ${{ secrets.env_vars }}
     with:
+      app-name: reference-infra-cloudsql
       tenant-name: reference-infra-cloudsql
       security-scan-blocking-severity: "off"
       working-directory: reference-infra-cloudsql

--- a/.github/workflows/reference-infra-tofu-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-infra-tofu-scheduled-security-scan.yaml
@@ -13,6 +13,7 @@ jobs:
     secrets:
       env_vars: ${{ secrets.env_vars }}
     with:
+      app-name: reference-infra-tofu
       tenant-name: reference-infra-tofu
       security-scan-blocking-severity: "off"
       working-directory: reference-infra-tofu

--- a/.github/workflows/reference-infra-urlrouter-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-infra-urlrouter-scheduled-security-scan.yaml
@@ -13,6 +13,7 @@ jobs:
     secrets:
       env_vars: ${{ secrets.env_vars }}
     with:
+      app-name: reference-infra-urlrouter
       tenant-name: reference-infra-urlrouter
       security-scan-blocking-severity: "off"
       working-directory: reference-infra-urlrouter

--- a/.github/workflows/reference-java-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-java-web-scheduled-security-scan.yaml
@@ -13,6 +13,7 @@ jobs:
     secrets:
       env_vars: ${{ secrets.env_vars }}
     with:
+      app-name: reference-java-web
       tenant-name: reference-java-web
       security-scan-blocking-severity: "off"
       working-directory: reference-java-web

--- a/.github/workflows/reference-nextjs-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-nextjs-web-scheduled-security-scan.yaml
@@ -13,6 +13,7 @@ jobs:
     secrets:
       env_vars: ${{ secrets.env_vars }}
     with:
+      app-name: reference-nextjs-web
       tenant-name: reference-nextjs-web
       security-scan-blocking-severity: "off"
       working-directory: reference-nextjs-web

--- a/.github/workflows/reference-python-web-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-python-web-scheduled-security-scan.yaml
@@ -13,6 +13,7 @@ jobs:
     secrets:
       env_vars: ${{ secrets.env_vars }}
     with:
+      app-name: reference-python-web
       tenant-name: reference-python-web
       security-scan-blocking-severity: "off"
       working-directory: reference-python-web

--- a/.github/workflows/reference-static-nextra-scheduled-security-scan.yaml
+++ b/.github/workflows/reference-static-nextra-scheduled-security-scan.yaml
@@ -13,6 +13,7 @@ jobs:
     secrets:
       env_vars: ${{ secrets.env_vars }}
     with:
+      app-name: reference-static-nextra
       tenant-name: reference-static-nextra
       security-scan-blocking-severity: "off"
       working-directory: reference-static-nextra


### PR DESCRIPTION
## Summary
- add app-name inputs to scheduled security scan workflows
- set each app-name to match the existing tenant-name value

## Testing
- verified workflow diff only includes the new app-name lines