### PR TITLE
Do not merge: reference-go-web security fixes

### DIFF
--- a/reference-go-web/p2p/tests/functional/go.mod
+++ b/reference-go-web/p2p/tests/functional/go.mod
@@ -16,6 +16,6 @@ require (
 	github.com/hashicorp/go-memdb v1.3.5 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	golang.org/x/net v0.51.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 )

--- a/reference-go-web/p2p/tests/functional/go.sum
+++ b/reference-go-web/p2p/tests/functional/go.sum
@@ -51,10 +51,10 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
-golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/reference-go-web/p2p/tests/integration/go.mod
+++ b/reference-go-web/p2p/tests/integration/go.mod
@@ -16,6 +16,6 @@ require (
 	github.com/hashicorp/go-memdb v1.3.5 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	golang.org/x/net v0.51.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 )

--- a/reference-go-web/p2p/tests/integration/go.sum
+++ b/reference-go-web/p2p/tests/integration/go.sum
@@ -51,10 +51,10 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
-golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Do not merge

This PR should not be merged until the corresponding template changes are backported. `reference-go-web` is provisioned from templates for testing, so merging this repository-only change would drift from the templates.

## Changes

- Upgraded `golang.org/x/net` from `v0.51.0` to `v0.55.0` in `reference-go-web/p2p/tests/functional` and `reference-go-web/p2p/tests/integration`.
- Upgraded `golang.org/x/sys` from `v0.42.0` to `v0.45.0` in the same two test modules.
- Added no `.p2p-security-ignore.yaml` entries; all `reference-go-web` findings reproduced from the workflow source artifact were fixable by dependency upgrades.

## Findings addressed

The latest `reference-go-web Security Scan` artifact showed source findings under `reference-go-web/` only for `golang.org/x/net` CVEs `CVE-2026-25680`, `CVE-2026-25681`, `CVE-2026-27136`, `CVE-2026-33814`, `CVE-2026-39821`, `CVE-2026-42502`, and `CVE-2026-42506`, plus `golang.org/x/sys` `CVE-2026-39824`, duplicated across the functional and integration test modules.

## Validation

- `trivy fs --scanners vuln,secret --format json --output /tmp/reference-go-web-trivy-fs-final.json reference-go-web`: passed; final totals were `total_vulns=0 total_secrets=0`.
- `trufflehog filesystem --json reference-go-web`: passed; `verified_secrets=0`, `unverified_secrets=0`.
- `docker build -t reference-go-web:security-scan reference-go-web`: passed.
- `trivy image --cache-dir /tmp/trivy-reference-go-web-cache --scanners vuln,secret --format json --output /tmp/reference-go-web-trivy-image.json reference-go-web:security-scan`: passed; no vulnerability or secret result entries were present.
- `go test ./...` in `reference-go-web`: passed, 2 packages.
- `go test -run ^'$' ./...` in `reference-go-web/p2p/tests/functional`: passed compile-only check; full scenario test requires a running `service:8080` and ingress URL locally.
- `go test -run ^'$' ./...` in `reference-go-web/p2p/tests/integration`: passed compile-only check; full scenario test requires a running `service:8080` and ingress URL locally.

Full `go test ./...` in the functional and integration scenario modules was attempted and failed only because the local service/ingress dependencies were not running (`dial tcp: lookup service: no such host` / empty ingress URL).