### PR TITLE
Do not merge: reference-java-web security fixes

### DIFF
--- a/reference-java-web/.p2p-security-ignore.yaml
+++ b/reference-java-web/.p2p-security-ignore.yaml
@@ -1,0 +1,24 @@
+version: 1
+images:
+  - name: reference-java-web
+    secrets:
+      - id: p2psec_9756474ad1dca77c
+        path: /usr/lib/x86_64-linux-gnu/libgnutls.so.30.37.1
+        expires: 2026-09-23
+        reason: "Unverified Box pattern in Ubuntu libgnutls binary from the base image; no credential material is present and dependency upgrades already use the fixed available package revision."
+      - id: p2psec_d653005e4d23cf91
+        path: /usr/lib/x86_64-linux-gnu/libgnutls.so.30.37.1
+        expires: 2026-09-23
+        reason: "Unverified PrivateKey pattern in Ubuntu libgnutls binary from the base image; no credential material is present and dependency upgrades already use the fixed available package revision."
+      - id: p2psec_4d409f24673e54d7
+        path: /var/lib/dpkg/info/libc6:amd64.md5sums
+        expires: 2026-09-23
+        reason: "Unverified Box pattern in Ubuntu package checksum metadata from the base image; this is not an application secret."
+      - id: p2psec_0a7d3a58ac1bb931
+        path: /var/lib/dpkg/info/locales.md5sums
+        expires: 2026-09-23
+        reason: "Unverified Box pattern in Ubuntu package checksum metadata from the base image; this is not an application secret."
+      - id: p2psec_146d28c666737e01
+        path: /opt/java/openjdk/lib/server/libjvm.so
+        expires: 2026-09-23
+        reason: "Unverified Box pattern in the Eclipse Temurin JDK runtime library from the base image; this is not an application secret."


### PR DESCRIPTION
# Do not merge

This PR should not be merged until the corresponding template changes are backported. This repository is provisioned from templates for testing, so merging this rendered-project-only change would drift from the templates.

## Scope

- Subproject: reference-java-web only.
- Workflow inspected: reference-java-web Security Scan (.github/workflows/reference-java-web-scheduled-security-scan.yaml), working-directory reference-java-web.
- No reference-infra work was included.

## Changes

- Added reference-java-web/.p2p-security-ignore.yaml as a subproject-local P2P ignore file.
- No dependency or image-tag upgrades were needed in this branch. The Dockerfile already installs fixed Ubuntu package revisions for the Trivy OS package findings.
- Ignored unverified image-secret detections from TruffleHog in base-image/JDK binary or checksum files, all expiring 2026-09-23:
  - p2psec_9756474ad1dca77c at /usr/lib/x86_64-linux-gnu/libgnutls.so.30.37.1
  - p2psec_d653005e4d23cf91 at /usr/lib/x86_64-linux-gnu/libgnutls.so.30.37.1
  - p2psec_4d409f24673e54d7 at /var/lib/dpkg/info/libc6:amd64.md5sums
  - p2psec_0a7d3a58ac1bb931 at /var/lib/dpkg/info/locales.md5sums
  - p2psec_146d28c666737e01 at /opt/java/openjdk/lib/server/libjvm.so

## Validation

- Downloaded latest reference-java-web Security Scan artifacts from run 28021454897.
- Confirmed source SCA findings under reference-java-web: 0. The repository-wide source findings are in other subprojects and were excluded from this scoped fix.
- Confirmed P2P image artifact findings for reference-java-web are unverified TruffleHog detections in image binary/checksum paths.
- Ran docker build --platform linux/amd64 --progress=plain -t reference-java-web:security-scan-amd64 reference-java-web: passed; Gradle service build and tests passed inside the image build.
- Ran trivy image --format table --scanners vuln,secret --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --exit-code 0 --ignore-unfixed reference-java-web:security-scan-amd64: passed, 0 vulnerabilities for OS and service.jar.
- Ran trufflehog docker --image=docker://reference-java-web:security-scan-amd64 --json --results=verified,unverified,unknown --no-update: completed with 0 verified and 7 unverified detections.
- Applied the actual P2P ignore helper to downloaded CI image findings and local amd64 findings: fast-feedback active=0 ignored=6; extended-test active=0 ignored=6; prod active=0 ignored=6; local-amd64 active=0 ignored=7.
- Ran YAML validation for reference-java-web/.p2p-security-ignore.yaml: passed.