### PR TITLE
Do not merge: reference-python-web security fixes

### DIFF
--- a/reference-python-web/.p2p-security-ignore.yaml
+++ b/reference-python-web/.p2p-security-ignore.yaml
@@ -1,0 +1,24 @@
+version: 1
+images:
+  - name: reference-python-web
+    secrets:
+      - id: p2psec_2e745269d2a106a0
+        path: /var/lib/dpkg/info/libc6:amd64.md5sums
+        expires: 2026-09-23
+        reason: "False positive in Debian libc package checksum metadata, not an application secret."
+      - id: p2psec_ae7c9f95165aff0b
+        path: /app/.venv/lib/python3.14/site-packages/pydantic/networks.py
+        expires: 2026-09-23
+        reason: "False positive from public URI examples in the packaged pydantic URL validation code."
+      - id: p2psec_7f935aceca16787b
+        path: /app/.venv/lib/python3.14/site-packages/pydantic/networks.py
+        expires: 2026-09-23
+        reason: "False positive from public URI examples in the packaged pydantic URL validation code."
+      - id: p2psec_ca89328d0d75906f
+        path: /app/.venv/lib/python3.14/site-packages/pydantic/networks.py
+        expires: 2026-09-23
+        reason: "False positive from public URI examples in the packaged pydantic URL validation code."
+      - id: p2psec_8f2fad8d82532ee3
+        path: /usr/local/lib/python3.14/site-packages/pip/_vendor/urllib3/util/url.py
+        expires: 2026-09-23
+        reason: "False positive from public URI parsing examples in pip's vendored urllib3 code."


### PR DESCRIPTION
## Do not merge

This PR should not be merged until the corresponding reference-python-web template changes are backported. This repository is provisioned from templates for testing, so merging only the generated reference app would leave the source templates out of sync.

## Changes

- Added reference-python-web/.p2p-security-ignore.yaml scoped to image name reference-python-web.
- Ignored five TruffleHog image secret false positives from the latest reference-python-web Security Scan artifacts.
- No dependency or image tag upgrades were made: python:3.14.7-slim does not exist, python:3.14-slim resolves to the same manifest as python:3.14.6-slim, and uv lock --upgrade --dry-run only offered prometheus-fastapi-instrumentator 8.0.0 -> 8.0.2, which does not address the image secret findings.

## Ignored findings

All ignore entries expire on 2026-09-23.

- p2psec_2e745269d2a106a0 at /var/lib/dpkg/info/libc6:amd64.md5sums: Debian libc package checksum metadata false positive.
- p2psec_ae7c9f95165aff0b at /app/.venv/lib/python3.14/site-packages/pydantic/networks.py: public URI example false positive.
- p2psec_7f935aceca16787b at /app/.venv/lib/python3.14/site-packages/pydantic/networks.py: public URI example false positive.
- p2psec_ca89328d0d75906f at /app/.venv/lib/python3.14/site-packages/pydantic/networks.py: public URI example false positive.
- p2psec_8f2fad8d82532ee3 at /usr/local/lib/python3.14/site-packages/pip/_vendor/urllib3/util/url.py: public URI parser example false positive.

## Validation

- Inspected workflow reference-python-web Security Scan run 28021203250 and downloaded its source/image security artifacts.
- Confirmed source-security-findings.json has no vulnerabilities under reference-python-web/.
- Confirmed the same five active image secret IDs appear across fast-feedback, extended-test, and prod image artifacts, and all are matched by the local ignore file by id, path, image name, and expiry.
- ruby YAML validation: ignore file valid with five entries and expires 2026-09-23.
- yq parsed reference-python-web/.p2p-security-ignore.yaml successfully.
- trivy fs --scanners vuln --format json --skip-dirs .venv --skip-dirs __pycache__ .: no Vulnerabilities in reference-python-web.
- trufflehog filesystem --json --no-update .: verified_secrets=0, unverified_secrets=0.
