### PR TITLE
Update monitoring stack stage builds

### DIFF
--- a/reference-monitoring-stack/Makefile
+++ b/reference-monitoring-stack/Makefile
@@ -38,13 +38,16 @@ build-integration:
 	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" p2p/tests/integration/
 
 .PHONY: build-functional
-build-functional: build-integration
+build-functional:
+	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" p2p/tests/integration/
 
 .PHONY: build-nft
-build-nft: build-integration
+build-nft:
+	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" p2p/tests/integration/
 
 .PHONY: build-extended-test
-build-extended-test: build-integration
+build-extended-test:
+	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" p2p/tests/integration/
 
 .PHONY: build-%
 build-%:


### PR DESCRIPTION
## Summary
- render the monitoring-stack template fix into reference-monitoring-stack
- build the stage test image under each functional, NFT, and extended-test image tag

## Context
Functional and NFT failed because their build targets depended on build-integration. That built only the integration image tag while the later push steps expected functional/NFT tags.

Template source PR: coreeng/core-platform-software-templates#184

## Verification
- rendered from the local fixed monitoring-stack template
- ran git diff --cached --check