### PR TITLE
Allow monitoring stack subnamespace creation

### DIFF
--- a/.github/workflows/reference-monitoring-stack-extended-test.yaml
+++ b/.github/workflows/reference-monitoring-stack-extended-test.yaml
@@ -24,5 +24,4 @@ jobs:
       tenant-name: reference-monitoring-stack
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: reference-monitoring-stack/v
-      skip-subnamespaces-create: true
       working-directory: reference-monitoring-stack

--- a/.github/workflows/reference-monitoring-stack-fast-feedback.yaml
+++ b/.github/workflows/reference-monitoring-stack-fast-feedback.yaml
@@ -34,5 +34,4 @@ jobs:
       app-name: reference-monitoring-stack
       tenant-name: reference-monitoring-stack
       version: ${{ needs.version.outputs.version }}
-      skip-subnamespaces-create: true
       working-directory: reference-monitoring-stack

--- a/.github/workflows/reference-monitoring-stack-prod.yaml
+++ b/.github/workflows/reference-monitoring-stack-prod.yaml
@@ -24,5 +24,4 @@ jobs:
       tenant-name: reference-monitoring-stack
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: reference-monitoring-stack/v
-      skip-subnamespaces-create: true
       working-directory: reference-monitoring-stack


### PR DESCRIPTION
## Summary
- render the monitoring-stack workflow template update
- remove skip-subnamespaces-create from generated monitoring-stack fast-feedback, extended-test, and prod workflows

## Context
The monitoring stack reference app needs p2p to create its stage subnamespaces. The generated workflows previously disabled that setup step.

Template source PR: coreeng/core-platform-software-templates#185

## Verification
- rendered from the local template branch for #185
- ran git diff --cached --check