### PR TITLE
Avoid monitoring stack stage resource collisions

### DIFF
--- a/reference-monitoring-stack/Makefile
+++ b/reference-monitoring-stack/Makefile
@@ -60,12 +60,20 @@ push-%:
 .PHONY: deploy-%
 deploy-%:
 	helm repo add core-platform-assets https://coreeng.github.io/core-platform-assets --force-update
+	stage="$*"; \
+	name_override="$(p2p_app_name)"; \
+	app_url_suffix="$(p2p_app_url_suffix)"; \
+	if [[ "$$stage" != "prod" ]]; then \
+		if [[ "$$stage" == "extended-test" ]]; then stage="extended"; fi; \
+		name_override="$(p2p_app_name)-$$stage"; \
+		app_url_suffix=""; \
+	fi; \
 	helm upgrade --install "$(p2p_app_name)" core-platform-assets/core-platform-monitoring -n "$(p2p_namespace)" \
 		-f <(envsubst < p2p/config/common.yaml) \
 		-f <(envsubst < p2p/config/$*.yaml) \
-		--set nameOverride="$(p2p_app_name)" \
+		--set nameOverride="$$name_override" \
 		--set tenantName="$(p2p_tenant_name)" \
-		--set ingress.appUrlSuffix="$(p2p_app_url_suffix)" \
+		--set ingress.appUrlSuffix="$$app_url_suffix" \
 		--set ingress.domain="$(INTERNAL_SERVICES_DOMAIN)" \
 		--atomic
 


### PR DESCRIPTION
## Summary
- render monitoring-stack deploy naming fix
- use stage-specific chart names for non-prod monitoring-stack deploys
- keep prod using the base application chart name

## Context
Functional and NFT can deploy in parallel. The monitoring chart creates parent-namespace RBAC from nameOverride, so the previous shared name caused Helm ownership conflicts on Role reference-monitoring-stack-prometheus.

Template source PR: coreeng/core-platform-software-templates#186

## Verification
- rendered from the local template branch for #186
- ran git diff --cached --check
- dry-ran make deploy-functional, deploy-nft, deploy-extended-test, and deploy-prod command expansion